### PR TITLE
added pact_broker_basic_auth options to publish task

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ PactBroker::Client::PublicationTask.new do | task |
   require 'my_consumer/version'
   task.consumer_version = MyConsumer::VERSION
   task.pact_broker_base_url = "http://pact-broker.my.org"
+  task.pact_broker_basic_auth =  { username: 'basic_auth_user', password: 'basic_auth_pass'} #optional
 end
 ```
 

--- a/lib/pact_broker/client/base_client.rb
+++ b/lib/pact_broker/client/base_client.rb
@@ -26,11 +26,13 @@ module PactBroker
       include HTTParty
       include StringToSymbol
 
-      attr_reader :base_url
+      attr_reader :base_url, :client_options
 
       def initialize options
         @base_url = options[:base_url]
+        @client_options = options[:client_options] || {}
         self.class.base_uri base_url
+        self.class.basic_auth(client_options[:basic_auth][:username], client_options[:basic_auth][:password]) if client_options[:basic_auth]
       end
 
       def default_request_headers

--- a/lib/pact_broker/client/pact_broker_client.rb
+++ b/lib/pact_broker/client/pact_broker_client.rb
@@ -14,19 +14,20 @@ module PactBroker
 
       DEFAULT_OPTIONS = {base_url: DEFAULT_PACT_BROKER_BASE_URL}
 
-      attr_reader :base_url
+      attr_reader :base_url, :client_options
 
       def initialize options = {}
         merged_options = DEFAULT_OPTIONS.merge(options)
         @base_url = merged_options[:base_url]
+        @client_options = merged_options[:client_options] || {}
       end
 
       def pacticipants
-        PactBroker::Client::Pacticipants.new base_url: base_url
+        PactBroker::Client::Pacticipants.new base_url: base_url, client_options: client_options
       end
 
       def pacts
-        PactBroker::Client::Pacts.new base_url: base_url
+        PactBroker::Client::Pacts.new base_url: base_url, client_options: client_options
       end
 
     end

--- a/lib/pact_broker/client/pacticipants.rb
+++ b/lib/pact_broker/client/pacticipants.rb
@@ -5,7 +5,7 @@ module PactBroker
     class Pacticipants < BaseClient
 
       def versions
-        Versions.new base_url: base_url
+        Versions.new base_url: base_url, client_options: client_options
       end
 
       def update options

--- a/lib/pact_broker/client/publish_pacts.rb
+++ b/lib/pact_broker/client/publish_pacts.rb
@@ -5,10 +5,11 @@ module PactBroker
   module Client
     class PublishPacts
 
-      def initialize pact_broker_base_url, pact_files, consumer_version
+      def initialize pact_broker_base_url, pact_files, consumer_version, pact_broker_client_options={}
         @pact_broker_base_url = pact_broker_base_url
         @pact_files = pact_files
         @consumer_version = consumer_version
+        @pact_broker_client_options = pact_broker_client_options
       end
 
       def call
@@ -19,10 +20,10 @@ module PactBroker
 
       private
 
-      attr_reader :pact_broker_base_url, :pact_files, :consumer_version
+      attr_reader :pact_broker_base_url, :pact_files, :consumer_version, :pact_broker_client_options
 
       def pact_broker_client
-        @pact_broker_client ||= PactBroker::Client::PactBrokerClient.new(base_url: pact_broker_base_url)
+        @pact_broker_client ||= PactBroker::Client::PactBrokerClient.new(base_url: pact_broker_base_url, client_options: pact_broker_client_options)
       end
 
       def publish_pact pact_file

--- a/lib/pact_broker/client/tasks/publication_task.rb
+++ b/lib/pact_broker/client/tasks/publication_task.rb
@@ -15,7 +15,7 @@ module PactBroker
   module Client
     class PublicationTask < ::Rake::TaskLib
 
-      attr_accessor :pattern, :pact_broker_base_url, :consumer_version
+      attr_accessor :pattern, :pact_broker_base_url, :consumer_version, :pact_broker_basic_auth
 
       def initialize name = nil, &block
         @name = name
@@ -32,7 +32,8 @@ module PactBroker
           task task_name do
             block.call(self)
             require 'pact_broker/client/publish_pacts'
-            success = PactBroker::Client::PublishPacts.new(pact_broker_base_url, FileList[pattern], consumer_version).call
+            pact_broker_client_options = pact_broker_basic_auth ? {basic_auth: pact_broker_basic_auth} :{}
+            success = PactBroker::Client::PublishPacts.new(pact_broker_base_url, FileList[pattern], consumer_version, pact_broker_client_options).call
             raise "One or more pacts failed to be published" unless success
           end
         end

--- a/lib/pact_broker/client/versions.rb
+++ b/lib/pact_broker/client/versions.rb
@@ -32,7 +32,7 @@ module PactBroker
       end
 
       def pacts
-        Pacts.new base_url: base_url
+        Pacts.new base_url: base_url, client_options: client_options
       end
 
       private

--- a/spec/lib/pact_broker/client/base_client_spec.rb
+++ b/spec/lib/pact_broker/client/base_client_spec.rb
@@ -1,0 +1,51 @@
+require 'pact_broker/client/base_client'
+module PactBroker
+  module Client
+    describe BaseClient do
+      describe '#initialize' do
+        let(:base_url) { 'http://pact_broker_base_url'}
+        let(:username) { 'pact_repo_username'}
+        let(:password) { 'pact_repo_password'}
+        let(:client_options) do
+          {
+            basic_auth: {
+              username: username,
+              password: password
+            }
+          }
+        end
+        context 'with basic url' do
+          it 'should set base url' do
+            base_client = BaseClient.new(base_url: base_url)
+            expect(base_client.base_url).to eq(base_url)
+            expect(BaseClient.base_uri).to eq(base_url)
+          end
+        end
+
+        context 'with client options' do
+          subject { BaseClient.new(base_url: base_url, client_options: client_options) }
+          it 'should set client options ' do
+            expect(subject.client_options).to eq(client_options)
+          end
+
+          it 'should set httpparty basic auth when client options contains basic auth' do
+            expect(BaseClient).to receive(:basic_auth).with(username, password)
+            subject
+          end
+        end
+
+        context 'without client options' do
+          subject { BaseClient.new(base_url: base_url) }
+          it 'should set client options to empty hash ' do
+            expect(subject.client_options).to eq({})
+          end
+
+          it 'should not set httpparty basic auth' do
+            expect(BaseClient).to_not receive(:basic_auth).with(username, password)
+            subject
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/pact_broker/client/pact_broker_client_spec.rb
+++ b/spec/lib/pact_broker/client/pact_broker_client_spec.rb
@@ -5,14 +5,41 @@ require 'pact_broker/client'
 module PactBroker::Client
   describe PactBrokerClient do
 
+    let(:client_options) do
+      { some_option: 'option value'}
+    end
+    let(:base_url) { 'https://blah' }
+
     describe 'initialize' do
       subject { PactBrokerClient.new }
       it 'sets the base_uri to http://pact-broker by default' do
         expect(subject.base_url).to eq('http://pact-broker')
       end
 
+      it 'sets the client options to empty hash by default' do
+        expect(subject.client_options).to eq({})
+      end
+
       it 'allows configuration of the base_uri' do
-        expect(PactBrokerClient.new(base_url: 'https://blah').base_url).to eq('https://blah')
+        expect(PactBrokerClient.new(base_url: base_url).base_url).to eq(base_url)
+      end
+
+      it 'allows configuration of the client options' do
+        expect(PactBrokerClient.new(client_options: client_options).client_options).to eq(client_options)
+      end
+    end
+
+    describe 'pacticipants' do
+      it 'initializes pacticipants with base url and client options' do
+        expect(PactBroker::Client::Pacticipants).to receive(:new).with(base_url: base_url, client_options: client_options)
+        PactBrokerClient.new(base_url: base_url, client_options: client_options).pacticipants
+      end
+    end
+
+    describe 'pacts' do
+      it 'initializes [act] with base url and client options' do
+        expect(PactBroker::Client::Pacts).to receive(:new).with(base_url: base_url, client_options: client_options)
+        PactBrokerClient.new(base_url: base_url, client_options: client_options).pacts
       end
     end
   end

--- a/spec/lib/pact_broker/client/pacticipants_spec.rb
+++ b/spec/lib/pact_broker/client/pacticipants_spec.rb
@@ -1,0 +1,18 @@
+require 'pact_broker/client/pacticipants'
+module PactBroker
+  module Client
+    describe Pacticipants do
+      let(:client_options) do
+        { some_option: 'option value'}
+      end
+      let(:base_url) { 'https://blah' }
+
+      describe 'versions' do
+        it 'initializes versions with base url and client options' do
+          expect(PactBroker::Client::Versions).to receive(:new).with(base_url: base_url, client_options: client_options)
+          Pacticipants.new(base_url: base_url, client_options: client_options).versions
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/pact_broker/client/publish_pacts_spec.rb
+++ b/spec/lib/pact_broker/client/publish_pacts_spec.rb
@@ -10,7 +10,7 @@ module PactBroker
       before do
         FakeFS.activate!
         pacts_client.stub(:publish).and_return(latest_pact_url)
-        PactBroker::Client::PactBrokerClient.stub(:new).with(base_url: pact_broker_base_url).and_return(pact_broker_client)
+        PactBroker::Client::PactBrokerClient.stub(:new).with(base_url: pact_broker_base_url, client_options: pact_broker_client_options).and_return(pact_broker_client)
       end
 
       after do
@@ -24,8 +24,16 @@ module PactBroker
       let(:pact_hash) { {consumer: {name: 'Consumer'}, provider: {name: 'Provider'} } }
       let(:pacts_client) { instance_double("PactBroker::ClientSupport::Pacts")}
       let(:pact_broker_base_url) { 'http://some-host'}
+      let(:pact_broker_client_options) do
+        {
+          basic_auth: {
+            username: 'user',
+            password: 'pass'
+          }
+        }
+      end
 
-      subject { PublishPacts.new(pact_broker_base_url, pact_files, consumer_version) }
+      subject { PublishPacts.new(pact_broker_base_url, pact_files, consumer_version, pact_broker_client_options) }
 
       before do
         FileUtils.mkdir_p "spec/pacts"

--- a/spec/lib/pact_broker/client/tasks/publication_task_spec.rb
+++ b/spec/lib/pact_broker/client/tasks/publication_task_spec.rb
@@ -30,7 +30,7 @@ module PactBroker::Client
 
       context "when pacts are succesfully published" do
         it "invokes PublishPacts with the default values" do
-          PactBroker::Client::PublishPacts.should_receive(:new).with('http://pact-broker', pact_file_list, '1.2.3').and_return(publish_pacts)
+          PactBroker::Client::PublishPacts.should_receive(:new).with('http://pact-broker', pact_file_list, '1.2.3', {}).and_return(publish_pacts)
           publish_pacts.should_receive(:call).and_return(true)
           Rake::Task['pact:publish'].execute
         end
@@ -50,17 +50,19 @@ module PactBroker::Client
       before :all do
         @pact_broker_base_url = "http://some-host"
         @pattern = "pact/*.json"
+        @pact_broker_basic_auth = { username: 'user', password: 'pass'}
         PactBroker::Client::PublicationTask.new(:custom) do | task |
           task.consumer_version = '1.2.3'
           task.pact_broker_base_url = @pact_broker_base_url
           task.pattern = @pattern
+          task.pact_broker_basic_auth = @pact_broker_basic_auth
         end
       end
 
       let(:pattern) { @pattern }
 
       it "invokes PublishPacts with the customised values" do
-        PactBroker::Client::PublishPacts.should_receive(:new).with(@pact_broker_base_url, pact_file_list, '1.2.3')
+        PactBroker::Client::PublishPacts.should_receive(:new).with(@pact_broker_base_url, pact_file_list, '1.2.3', {basic_auth: @pact_broker_basic_auth})
         publish_pacts.should_receive(:call).and_return(true)
         Rake::Task['pact:publish:custom'].execute
       end

--- a/spec/lib/pact_broker/client/versions_spec.rb
+++ b/spec/lib/pact_broker/client/versions_spec.rb
@@ -1,0 +1,18 @@
+require 'pact_broker/client/versions'
+module PactBroker
+  module Client
+    describe Versions do
+      let(:client_options) do
+        { some_option: 'option value'}
+      end
+      let(:base_url) { 'https://blah' }
+
+      describe 'pacts' do
+        it 'initializes versions with base url and client options' do
+          expect(PactBroker::Client::Pacts).to receive(:new).with(base_url: base_url, client_options: client_options)
+          Versions.new(base_url: base_url, client_options: client_options).pacts
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi,

I've forked the pact, pact-support and pact_broker-client repository and made the changes on the 'basic_auth' branch for each project and created pull request.

The main changes are:

#### pact-support
pass the basic auth option to PactFile open method

#### pact
* added the basic auth options in dsl 
```ruby
honours_pact_with 'ServiceConsumer' do
    pact_uri 'http://pact-broker-url/consumer/ServiceConsumer/latest', {username: 'user', password: 'pass'}
end
```
* when running pact:verify:at['pact_broker_url'] task, currently I just let users to set environment variables PACT_REPO_USERNAME, PACT_REPO_PASSWORD for the basic auth information.  I am not sure whether it's good enough.

#### pact_broker_client
 pass optional pact_broker_basic_auth in the PublicationTask

```ruby
task.pact_broker_basic_auth =  { username: 'basic_auth_user', password: 'basic_auth_pass'} #optional 
```

#### Testing
* I've added unit tests for my changes.  The rake tasks of all the three projects all passed. 
* I used my version to run pact:verify, pact:verify:at['pact_url'] and publication task pointing to our pact broker with basic authentication and without basic authentication.  They both worked. 

#### Documentation:
I've updated the README.md file in the pact_broker-client project.  But for the pact:verify part, I am not sure where to put the examples.  


I am not sure whether my change matches your code convention. Please review my changes and I will revise based on your feedback.  Thanks.