### PR TITLE
Loosen content type header expectation

### DIFF
--- a/spec/pacts/pact_broker_client-pact_broker.json
+++ b/spec/pacts/pact_broker_client-pact_broker.json
@@ -18,7 +18,17 @@
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/hal+json"
+          "Content-Type": {
+            "json_class": "Pact::Term",
+            "data": {
+              "generate": "application/hal+json",
+              "matcher": {
+                "json_class": "Regexp",
+                "o": 0,
+                "s": "application/hal\\+json"
+              }
+            }
+          }
         },
         "body": {
           "_links": {
@@ -78,7 +88,17 @@
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/hal+json"
+          "Content-Type": {
+            "json_class": "Pact::Term",
+            "data": {
+              "generate": "application/hal+json",
+              "matcher": {
+                "json_class": "Regexp",
+                "o": 0,
+                "s": "application/hal\\+json"
+              }
+            }
+          }
         },
         "body": {
           "_links": {
@@ -127,7 +147,17 @@
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/hal+json"
+          "Content-Type": {
+            "json_class": "Pact::Term",
+            "data": {
+              "generate": "application/hal+json",
+              "matcher": {
+                "json_class": "Regexp",
+                "o": 0,
+                "s": "application/hal\\+json"
+              }
+            }
+          }
         },
         "body": {
           "_links": {
@@ -297,7 +327,17 @@
       "response": {
         "status": 500,
         "headers": {
-          "Content-Type": "application/json"
+          "Content-Type": {
+            "json_class": "Pact::Term",
+            "data": {
+              "generate": "application/json",
+              "matcher": {
+                "json_class": "Regexp",
+                "o": 0,
+                "s": "application/json"
+              }
+            }
+          }
         },
         "body": {
           "message": {
@@ -390,7 +430,17 @@
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/json",
+          "Content-Type": {
+            "json_class": "Pact::Term",
+            "data": {
+              "generate": "application/json",
+              "matcher": {
+                "json_class": "Regexp",
+                "o": 0,
+                "s": "application/json"
+              }
+            }
+          },
           "X-Pact-Consumer-Version": "1.3.0"
         },
         "body": {

--- a/spec/service_providers/extra_goodies_spec.rb
+++ b/spec/service_providers/extra_goodies_spec.rb
@@ -33,7 +33,7 @@ module PactBroker::Client
               method: :get,
               path: '/pacts/latest',
               headers: {} ).
-            will_respond_with( headers: {'Content-Type' => 'application/hal+json'},
+            will_respond_with( headers: {'Content-Type' => Pact.term(generate: 'application/hal+json', matcher: %r{application/hal\+json})},
               status: 200,
               body: response_body
             )
@@ -55,7 +55,7 @@ module PactBroker::Client
               method: :get,
               path: '/pacticipants',
               headers: {} ).
-            will_respond_with( headers: {'Content-Type' => 'application/hal+json'},
+            will_respond_with( headers: {'Content-Type' => Pact.term(generate: 'application/hal+json', matcher: %r{application/hal\+json})},
               status: 200,
               body: response_body
             )
@@ -78,7 +78,7 @@ module PactBroker::Client
               method: :get,
               path: '/pacticipants/Pricing%20Service',
               headers: {} ).
-            will_respond_with( headers: {'Content-Type' => 'application/hal+json'},
+            will_respond_with( headers: {'Content-Type' => Pact.term(generate: 'application/hal+json', matcher: %r{application/hal\+json})},
               status: 200,
               body: response_body
             )

--- a/spec/service_providers/pact_broker_client_publish_spec.rb
+++ b/spec/service_providers/pact_broker_client_publish_spec.rb
@@ -101,7 +101,7 @@ module PactBroker::Client
               body: pact_hash ).
             will_respond_with(
               status: 500,
-              headers: {'Content-Type' => 'application/json'},
+              headers: {'Content-Type' => Pact.term(generate: 'application/json', matcher: %r{application/json})},
               body: {
                 message: Pact::Term.new(matcher: /.*/, generate: 'An error occurred')
               }

--- a/spec/service_providers/pact_broker_client_retrive_pact_spec.rb
+++ b/spec/service_providers/pact_broker_client_retrive_pact_spec.rb
@@ -31,7 +31,12 @@ module PactBroker::Client
       describe "finding the latest version" do
         context "when a pact is found" do
 
-          let(:response_headers) { pact_broker_response_headers.merge({'Content-Type' => 'application/json', 'X-Pact-Consumer-Version' => consumer_version}) }
+          let(:response_headers) do
+            pact_broker_response_headers.merge(
+              'Content-Type' => Pact.term(generate: 'application/json', matcher: %r{application/json}),
+              'X-Pact-Consumer-Version' => consumer_version
+            )
+          end
           before do
             pact_broker.
               given("a pact between Condor and the Pricing Service exists").

--- a/spec/service_providers/pact_broker_client_retrive_pact_spec.rb
+++ b/spec/service_providers/pact_broker_client_retrive_pact_spec.rb
@@ -93,7 +93,6 @@ module PactBroker::Client
               ).
               will_respond_with(
                 status: 200,
-                headers: {'Content-Type' => 'application/json', 'X-Pact-Consumer-Version' => consumer_version},
                 body: pact_hash,
                 headers: pact_broker_response_headers
               )


### PR DESCRIPTION
pact_broker might respond with `charset` field in `Content-Type` header.

Related with https://github.com/bethesque/pact_broker/pull/46