### PR TITLE
Warn on overwritting pact file

### DIFF
--- a/lib/pact_broker/client/pacts.rb
+++ b/lib/pact_broker/client/pacts.rb
@@ -21,6 +21,10 @@ module PactBroker
         end
       end
 
+      def version_published?(args)
+        !get(consumer: args.fetch(:consumer), provider: args.fetch(:provider), consumer_version: args.fetch(:consumer_version)).nil?
+      end
+
       def get options
         url = get_consumer_contract_url(options)
         response = self.class.get(url, headers: default_get_headers)

--- a/pact-broker-client.gemspec
+++ b/pact-broker-client.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'pact'
   gem.add_runtime_dependency 'httparty'
   gem.add_runtime_dependency 'json' #Not locking down a version because buncher gem requires 1.6, while other projects use 1.7.
+  gem.add_runtime_dependency 'term-ansicolor'
 
   #gem.add_development_dependency 'geminabox-client'
   gem.add_development_dependency 'rake', '~> 10.0.3'

--- a/spec/lib/pact_broker/client/publish_pacts_spec.rb
+++ b/spec/lib/pact_broker/client/publish_pacts_spec.rb
@@ -22,7 +22,7 @@ module PactBroker
       let(:pact_broker_client) { double("PactBroker::Client")}
       let(:pact_files) { ['spec/pacts/consumer-provider.json']}
       let(:consumer_version) { "1.2.3" }
-      let(:pact_hash) { {consumer: {name: 'Consumer'}, provider: {name: 'Provider'} } }
+      let(:pact_hash) { {consumer: {name: 'Consumer'}, provider: {name: 'Provider'}, interactions: [] } }
       let(:pacts_client) { instance_double("PactBroker::ClientSupport::Pacts")}
       let(:pact_broker_base_url) { 'http://some-host'}
       let(:pact_broker_client_options) do
@@ -40,6 +40,7 @@ module PactBroker
         FileUtils.mkdir_p "spec/pacts"
         File.open("spec/pacts/consumer-provider.json", "w") { |file| file << pact_hash.to_json }
         allow(pact_broker_client).to receive_message_chain(:pacticipants, :versions, :pacts).and_return(pacts_client)
+        allow(pacts_client).to receive(:version_published?).and_return(false)
       end
 
       describe "call" do


### PR DESCRIPTION
Sometimes it is useful for developers using Pact to warn this, in my opinion. How about?

I tested this with my own pact broker.