### PR TITLE
Add the option to retrieve all the latest (tagged) pacts for a provider

### DIFF
--- a/lib/pact_broker/client/pacts.rb
+++ b/lib/pact_broker/client/pacts.rb
@@ -46,6 +46,14 @@ module PactBroker
         end
       end
 
+      def list_latest_for_provider options
+        url = get_latest_provider_contracts(options)
+        response = self.class.get(url, headers: {})
+        handle_response(response) do
+          map_latest_provider_pacts_to_hash JSON.parse(response.body)["_links"]["pacts"]
+        end
+      end
+
       def latest options
         url = get_latest_consumer_contract_url(options)
         response = self.class.get(url, headers: default_get_headers)
@@ -73,6 +81,15 @@ module PactBroker
         end
       end
 
+      def map_latest_provider_pacts_to_hash pacts_list
+      pacts_list.collect do |pact_hash|
+        {
+            name: pact_hash["name"],
+            href: pact_hash["href"]
+        }
+      end
+    end
+
       def find_latest_link response
         links = response['_links']
         return nil unless links
@@ -96,6 +113,12 @@ module PactBroker
         provider_name = encode_param(options[:provider])
         tag = options[:tag] ? "/#{options[:tag]}" : ""
         "/pacts/provider/#{provider_name}/consumer/#{consumer_name}/latest#{tag}"
+      end
+
+      def get_latest_provider_contracts options
+        provider_name = encode_param(options[:provider])
+        tag = options[:tag] ? "/#{options[:tag]}" : ""
+        "/pacts/provider/#{provider_name}/latest#{tag}"
       end
 
       def get_consumer_contract_url options

--- a/spec/pacts/pact_broker_client-pact_broker.json
+++ b/spec/pacts/pact_broker_client-pact_broker.json
@@ -630,6 +630,66 @@
           }
         }
       }
+    },
+    {
+      "description": "a request for the list of the latest prod pacts from all consumers for the Pricing Service'",
+      "provider_state": "tagged as prod pact between Condor and the Pricing Service exists",
+      "request": {
+        "method": "get",
+        "path": "/pacts/provider/Pricing%20Service/latest/prod",
+        "headers": {
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "_links": {
+            "provider": {
+              "href": "http://example.org/pacticipants/Pricing%20Service",
+              "title": "Pricing%20Service"
+            },
+            "pacts": [
+              {
+                "href": "http://example.org/pacts/provider/Pricing%20Service/consumer/Condor/version/1.3.0",
+                "title": "Pact between Condor (v1.3.0) and Pricing%20Service",
+                "name": "Condor"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "description": "a request for the list of the latest pacts from all consumers for the Pricing Service'",
+      "provider_state": "a latest pact between Condor and the Pricing Service exists",
+      "request": {
+        "method": "get",
+        "path": "/pacts/provider/Pricing%20Service/latest",
+        "headers": {
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "_links": {
+            "provider": {
+              "href": "http://example.org/pacticipants/Pricing%20Service",
+              "title": "Pricing%20Service"
+            },
+            "pacts": [
+              {
+                "href": "http://example.org/pacts/provider/Pricing%20Service/consumer/Condor/version/1.3.0",
+                "title": "Pact between Condor (v1.3.0) and Pricing%20Service",
+                "name": "Condor"
+              }
+            ]
+          }
+        }
+      }
     }
   ],
   "metadata": {

--- a/spec/service_providers/pact_broker_client_retrieve_all_pacts_for_provider_spec.rb
+++ b/spec/service_providers/pact_broker_client_retrieve_all_pacts_for_provider_spec.rb
@@ -1,0 +1,53 @@
+require_relative 'pact_helper'
+require 'pact_broker/client'
+
+module PactBroker::Client
+  describe Pacts, :pact => true do
+
+    include_context "pact broker"
+
+    describe "retriving all pacts for provider" do
+      let(:response_body) { JSON.parse(File.read("./spec/support/latest_pacts_for_provider.json")) }
+      let(:expectedPactsArray) { [{:name => "Condor", :href => "http://example.org/pacts/provider/Pricing%20Service/consumer/Condor/version/1.3.0"}] }
+
+      context "when retrieving all the latest pacts for provider with prod tag specified" do
+        before do
+          pact_broker.
+              given("tagged as prod pact between Condor and the Pricing Service exists").
+              upon_receiving("a request for the list of the latest prod pacts from all consumers for the Pricing Service'").
+              with(
+                  method: :get,
+                  path: "/pacts/provider/Pricing%20Service/latest/prod",
+                  headers: {}).
+              will_respond_with(
+                  status: 200,
+                  body: response_body)
+        end
+        it 'returns the map of all provider latest prod pacts' do
+          pactsArray = pact_broker_client.pacticipants.versions.pacts.list_latest_for_provider provider: 'Pricing Service', tag: 'prod'
+          expect(pactsArray.length).to eq(1)
+          expect(pactsArray).to eq(expectedPactsArray)
+        end
+      end
+      context "when retrieving all the latest pacts for provider with no tag specified" do
+        before do
+          pact_broker.
+              given("a latest pact between Condor and the Pricing Service exists").
+              upon_receiving("a request for the list of the latest pacts from all consumers for the Pricing Service'").
+              with(
+                  method: :get,
+                  path: "/pacts/provider/Pricing%20Service/latest",
+                  headers: {}).
+              will_respond_with(
+                  status: 200,
+                  body: response_body)
+        end
+        it 'returns the map of all provider latest pacts' do
+          pactsArray = pact_broker_client.pacticipants.versions.pacts.list_latest_for_provider provider: 'Pricing Service'
+          expect(pactsArray.length).to eq(1)
+          expect(pactsArray).to eq(expectedPactsArray)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/latest_pacts_for_provider.json
+++ b/spec/support/latest_pacts_for_provider.json
@@ -1,0 +1,15 @@
+{
+  "_links": {
+    "provider": {
+      "href": "http://example.org/pacticipants/Pricing%20Service",
+      "title": "Pricing%20Service"
+    },
+    "pacts": [
+      {
+        "href": "http://example.org/pacts/provider/Pricing%20Service/consumer/Condor/version/1.3.0",
+        "title": "Pact between Condor (v1.3.0) and Pricing%20Service",
+        "name": "Condor"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR makes it possible to retrieve all the latest pacts (with/without a tag) for all consumers for a provider from pact broker.
The pacts list is returned as an array where each element of an array is a hash with pact 'name' and 'href'  #key.
This makes it easier to obtain all the pacts for a provider dynamically and iterate through them in pact_helper.

An example of usage in pact_helper:
```pact_broker_client = PactBroker::Client::PactBrokerClient.new({base_url: PACT_BROKER})
  pacts = pact_broker_client.pacticipants.versions.pacts.list_latest_for_provider provider: 'MyProvider', tag: 'prod'

  pacts.each do |pact|
    honours_pact_with pact[:name] do
      pact_uri pact[:href]
    end
  end
```