### PR TITLE
Fix provider name in pact_broker_client-pact_broker.json

### DIFF
--- a/spec/pacts/pact_broker_client-pact_broker.json
+++ b/spec/pacts/pact_broker_client-pact_broker.json
@@ -443,12 +443,12 @@
           "_links": {
             "provider": {
               "href": "http://example.org/pacticipants/Pricing%20Service",
-              "title": "Pricing%20Service"
+              "title": "Pricing Service"
             },
             "pacts": [
               {
                 "href": "http://example.org/pacts/provider/Pricing%20Service/consumer/Condor/version/1.3.0",
-                "title": "Pact between Condor (v1.3.0) and Pricing%20Service",
+                "title": "Pact between Condor (v1.3.0) and Pricing Service",
                 "name": "Condor"
               }
             ]
@@ -473,12 +473,12 @@
           "_links": {
             "provider": {
               "href": "http://example.org/pacticipants/Pricing%20Service",
-              "title": "Pricing%20Service"
+              "title": "Pricing Service"
             },
             "pacts": [
               {
                 "href": "http://example.org/pacts/provider/Pricing%20Service/consumer/Condor/version/1.3.0",
-                "title": "Pact between Condor (v1.3.0) and Pricing%20Service",
+                "title": "Pact between Condor (v1.3.0) and Pricing Service",
                 "name": "Condor"
               }
             ]

--- a/spec/support/latest_pacts_for_provider.json
+++ b/spec/support/latest_pacts_for_provider.json
@@ -2,12 +2,12 @@
   "_links": {
     "provider": {
       "href": "http://example.org/pacticipants/Pricing%20Service",
-      "title": "Pricing%20Service"
+      "title": "Pricing Service"
     },
     "pacts": [
       {
         "href": "http://example.org/pacts/provider/Pricing%20Service/consumer/Condor/version/1.3.0",
-        "title": "Pact between Condor (v1.3.0) and Pricing%20Service",
+        "title": "Pact between Condor (v1.3.0) and Pricing Service",
         "name": "Condor"
       }
     ]


### PR DESCRIPTION
In order to fix the tests in pact-broker.
This will need to be merged to master for the pact-broker tests to pass again.